### PR TITLE
TODO comment and regression removed

### DIFF
--- a/test/invariant/regressions/MZeroRegressions.t.sol
+++ b/test/invariant/regressions/MZeroRegressions.t.sol
@@ -41,20 +41,6 @@ contract MZeroRegressionTests is MZeroInvariants {
         _mTokenHandler.setMaxLeap(maxLeap);
     }
 
-    // TODO: we need to re-enable these tests once the issue is resolved in
-    // BatchGovernorHandler.  For now, this is squelched with:
-    // addExpectedError("NotPastTimepoint(uint48,uint48)");
-    // function test_regression_invariant_DV_B1_f8a6cc61_failure() external {
-    //     _setMaxLeap(3600);
-    //     _distributionVaultHandler.claim(115792089237316195423570985008687907853269984665640564039457584007913129639935, 246728611478136088800327302358230127, 115792089237316195423570985008687907853269984665640564039457584007913129639935, 1);
-    //     _powerTokenHandler.approve(3, 3, 115792089237316195423570985008687907853269984665640564039457584007913129639933);
-    //     _distributionVaultHandler.distribute(15162, 3825);
-    //     _powerTokenHandler.setNextCashToken(7251839516968295198182705805467140488838636843, 0);
-    //     _standardGovernorHandler.castVoteWithReason(208, 23262, 116);
-
-    //     invariant_DV_B1();
-    // }
-
     // DistributionVaultHandler.distribute()
     // function test_regression_invariant_ZT_VD2_9aabc167_failure() external {
     //     _setMaxLeap(1000000);

--- a/test/invariant/regressions/TTGRegressions.t.sol
+++ b/test/invariant/regressions/TTGRegressions.t.sol
@@ -39,21 +39,6 @@ contract TTGRegressionTests is TTGInvariants {
         _registrarHandler.setMaxLeap(maxLeap);
     }
 
-    // TODO: we need to re-enable these tests once the issue is resolved in
-    // BatchGovernorHandler.  For now, this is squelched with:
-    // addExpectedError("NotPastTimepoint(uint48,uint48)");
-    // function test_regression_invariant_DV_B1_f8a6cc61_failure() external {
-    //     _standardGovernorHandler.setMaxLeap(3600);
-    //     _distributionVaultHandler.claim(115792089237316195423570985008687907853269984665640564039457584007913129639935, 246728611478136088800327302358230127, 115792089237316195423570985008687907853269984665640564039457584007913129639935, 1);
-    //     _powerTokenHandler.approve(3, 3, 115792089237316195423570985008687907853269984665640564039457584007913129639933);
-    //     _distributionVaultHandler.distribute(15162, 3825);
-    //     _powerTokenHandler.setNextCashToken(7251839516968295198182705805467140488838636843, 0);
-    //     _standardGovernorHandler.castVoteWithReason(208, 23262, 116);
-
-    //     invariant_DV_B1();
-    // }
-
-
     // // =========== Further Exploration Required ===========
 
     // function test_regression_invariant_P_B1_c789f613_failure() external {


### PR DESCRIPTION
This TODO was related to us adding the blanket `addExpectedError("NotPastTimepoint(uint48,uint48)")` in `BatchGovernorHandler`.  When possible, we preferred to identify exactly the condition we knew an error would be expected, and add an exception only in that case so that we could better identify when an error might occur outside of expected parameters.  In this case, the timepoint is way beyond the epoch because we randomly rolled it to be.

If you want, you can try to identify when this error should happen and only `addExpectedError("NotPastTimepoint(uint48,uint48)")` in those cases, but for now, I don't want these commented out regressions or the TODO to confuse anyone.  I forgot to remove these in the regression tests when I removed their equivalents in the code, so this is just housekeeping to fix that.